### PR TITLE
Feature/allow specification of rustfmt arguments

### DIFF
--- a/BeautifyRust.py
+++ b/BeautifyRust.py
@@ -60,7 +60,7 @@ class BeautifyRustCommand(sublime_plugin.TextCommand):
         if buffer_text == "":
             return
         rustfmt_bin = which(self.settings.get("rustfmt", "rustfmt"))
-        if rustfmt_bin == None:
+        if rustfmt_bin is None:
             return sublime.error_message(
                 "Beautify rust: can not find {0} in path.".format(self.settings.get("rustfmt", "rustfmt")))
         cmd_list = [rustfmt_bin, self.filename, "--write-mode=overwrite"]

--- a/BeautifyRust.py
+++ b/BeautifyRust.py
@@ -63,7 +63,7 @@ class BeautifyRustCommand(sublime_plugin.TextCommand):
         if rustfmt_bin is None:
             return sublime.error_message(
                 "Beautify rust: can not find {0} in path.".format(self.settings.get("rustfmt", "rustfmt")))
-        cmd_list = [rustfmt_bin, self.filename, "--write-mode=overwrite"]
+        cmd_list = [rustfmt_bin, self.filename, "--write-mode=overwrite"] + self.settings.get("args", [])
         self.save_viewport_state()
         (exit_code, err) = self.pipe(cmd_list)
         if exit_code != 0 or (err != "" and not err.startswith("Using rustfmt")):


### PR DESCRIPTION
This allows the user to specify additional arguments to pass to rustfmt.

The use case I have for this is allowing the user to specify their own rustfmt.toml which may not exist within the crate's directory.
