### PR TITLE
Use shutil.which to find executable

### DIFF
--- a/BeautifyRust.py
+++ b/BeautifyRust.py
@@ -1,4 +1,5 @@
 import os.path
+import shutil
 import sublime
 import sublime_plugin
 import subprocess
@@ -14,12 +15,7 @@ def which(program):
         if is_exe(program):
             return program
     else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            path = path.strip('"')
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-    return None
+        return shutil.which(program)
 
 
 class BeautifyRustOnSave(sublime_plugin.EventListener):


### PR DESCRIPTION
The existing method for searching PATH for the configured rustfmt binary
causes problems if you use the same config across platforms. On Windows,
the program needs to be "rustfmt.exe", not simply "rustfmt", whereas on
macOS or Linux, the opposite is the case. This means users can't share
config between those systems (by symlinking to Dropbox or similar).

Python 3 comes with shutil.which() which does everything we need here
including appending ".exe" on Windows if that's not already there.