### PR TITLE
Change rustfmt --write-mode flag to --emit

### DIFF
--- a/BeautifyRust.py
+++ b/BeautifyRust.py
@@ -59,7 +59,8 @@ class BeautifyRustCommand(sublime_plugin.TextCommand):
         if rustfmt_bin is None:
             return sublime.error_message(
                 "Beautify rust: can not find {0} in path.".format(self.settings.get("rustfmt", "rustfmt")))
-        cmd_list = [rustfmt_bin, self.filename, "--write-mode=overwrite"] + self.settings.get("args", [])
+        cmd_list = [rustfmt_bin, self.filename, "--emit=files"] + \
+            self.settings.get("args", [])
         self.save_viewport_state()
         (exit_code, err) = self.pipe(cmd_list)
         if exit_code != 0 or (err != "" and not err.startswith("Using rustfmt")):


### PR DESCRIPTION
rust-lang-nursery/rustfmt@5d9f5aa05a668e7dfef87b46d89dad2884df9d41 removed the `--write-mode` flag and replaced it with `--emit`.