### PR TITLE
Remove --write-mode option

### DIFF
--- a/BeautifyRust.py
+++ b/BeautifyRust.py
@@ -59,7 +59,7 @@ class BeautifyRustCommand(sublime_plugin.TextCommand):
         if rustfmt_bin is None:
             return sublime.error_message(
                 "Beautify rust: can not find {0} in path.".format(self.settings.get("rustfmt", "rustfmt")))
-        cmd_list = [rustfmt_bin, self.filename, "--write-mode=overwrite"] + self.settings.get("args", [])
+        cmd_list = [rustfmt_bin, self.filename] + self.settings.get("args", [])
         self.save_viewport_state()
         (exit_code, err) = self.pipe(cmd_list)
         if exit_code != 0 or (err != "" and not err.startswith("Using rustfmt")):


### PR DESCRIPTION
This is no longer accepted (or required) in newer versions of rustfmt.